### PR TITLE
Fix copyright/license/attribution in rustls files

### DIFF
--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -1,6 +1,9 @@
+// Taken from rustls <https://github.com/rustls/rustls>
+//
+// Copyright (c) 2016 Joe Birr-Pixton and rustls project contributors
 // Copyright (c) 2020 Intel Corporation
 //
-// SPDX-License-Identifier: BSD-2-Clause-Patent
+// SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Debug;
 

--- a/codec/src/macros.rs
+++ b/codec/src/macros.rs
@@ -1,6 +1,9 @@
+// Taken from rustls <https://github.com/rustls/rustls>
+//
+// Copyright (c) 2016 Joe Birr-Pixton and rustls project contributors
 // Copyright (c) 2020 Intel Corporation
 //
-// SPDX-License-Identifier: BSD-2-Clause-Patent
+// SPDX-License-Identifier: Apache-2.0
 
 /// A macro which defines an enum type.
 #[macro_export]


### PR DESCRIPTION
These files were taken from [rustls circa 0.17](https://github.com/rustls/rustls/blob/v/0.17.0/rustls/src/msgs/codec.rs), but unfortunately the license is incorrect (rustls was never available under BSD license) and the Intel copyright claim is misleading when presented alone.

Feels pretty stinky.

I will send the same PR to [the upstream](https://github.com/intel/rust-spdm).